### PR TITLE
Basic implementation of privacy provider (null_provider)

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,49 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Privacy Subsystem implementation for QuizExport.
+ *
+ * @package   quiz_export\privacy
+ * @copyright 2020 CBlue Srl
+ * @copyright based on work by 2014 Johannes Burk
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace quiz_export\privacy;
+
+defined('MOODLE_INTERNAL') || die;
+
+/**
+ * Privacy Subsystem for QuizExport implementing null_provider.
+ *
+ * @package   quiz_export\privacy
+ * @copyright 2020 CBlue Srl
+ * @copyright based on work by 2014 Johannes Burk
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class provider implements \core_privacy\local\metadata\null_provider {
+
+    /**
+     * Get the language string identifier with the component's language
+     * file to explain why this plugin stores no data.
+     *
+     * @return  string
+     */
+    public static function get_reason(): string {
+        return 'privacy:metadata';
+    }
+}

--- a/lang/en/quiz_export.php
+++ b/lang/en/quiz_export.php
@@ -32,6 +32,9 @@ $string['exportattemptcheck'] = 'Export selected attempts?';
 
 $string['exportattempt'] = 'Export attempt';
 
+// Privacy.
+$string['privacy:metadata'] = 'QuizExport plugin does not store any personal data.';
+
 // export_form
 $string['exportsettings'] = 'Export Settings';
 $string['pagemode'] = 'Page mode (Page break mode while rendering quiz review before converting to PDF)';

--- a/lang/fr/quiz_export.php
+++ b/lang/fr/quiz_export.php
@@ -32,6 +32,9 @@ $string['exportattemptcheck'] = 'Exporter les tentatives sélectionnées ?';
 
 $string['exportattempt'] = 'Exporter cette tentative en pdf';
 
+// Privacy.
+$string['privacy:metadata'] = 'Le plugin QuizExport ne stocke aucune donnée personnelle.';
+
 // export_form
 $string['exportsettings'] = 'Paramètres d\'export';
 $string['pagemode'] = 'Mode de pagination (La manière dont vont être gérés les sauts de page lors de l\'export PDF)';


### PR DESCRIPTION
Recently I was adding privacy providers to some our plugins. I have found that quiz export is also missing a privacy provider. 
So I decided to add a basic provider, one which implements just `null_provider` interface.

You can see the changes in forked repo:

- https://github.com/wiktorwandachowicz/moodle-quiz_export/commit/d98601a14d04cc1fc5593e780570eb22a583edb3

Moodle Privacy API documentation, if you are interested:

- https://moodledev.io/docs/4.5/apis/subsystems/privacy